### PR TITLE
Use IP address range rather than single IP

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,7 +45,7 @@ zone_ports:
 
 allow_inter_vm_connections: false
 inter_vm_rules:
-  - ip: ""
+  - address: ""
     port: ""
 
 # rich_rules should be a list of hashes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,7 +43,7 @@
 - name: Allow inter-vm connections
   become: true
   ansible.posix.firewalld:
-    rich_rule: "rule family=ipv4 source address={{ item.ip }}/32 port protocol=tcp port={{ item.port }} accept"
+    rich_rule: "rule family=ipv4 source address={{ item.address }} port protocol=tcp port={{ item.port }} accept"
     zone: internal
     permanent: true
     immediate: true


### PR DESCRIPTION
When allowing connections between VMs on the same private network use full address range instead of a single IP in creating the rich rule.