### PR TITLE
Remove `internal_networks` and `work_networks`

### DIFF
--- a/molecule/resources/inventory/group_vars/db/vars
+++ b/molecule/resources/inventory/group_vars/db/vars
@@ -1,9 +1,5 @@
 ---
 allow_public_access: false
-internal_networks:
-  - "172.17.0.0/24"
-work_networks:
-  - "0.0.0.0/0"
 
 rich_rules:
   - { zone: "internal", rule: "family=ipv4 source address=172.17.0.3/32 port protocol=tcp port=5432 accept" }

--- a/molecule/resources/inventory/group_vars/web/vars
+++ b/molecule/resources/inventory/group_vars/web/vars
@@ -10,10 +10,7 @@ public_zone_open_services:
 work_zone_open_services:
   - http
   - https
-internal_networks:
-  - "172.17.0.0/24"
-work_networks:
-  - "0.0.0.0/0"
+
 internal_zone_ports:
   - "4063"
   - "4064"


### PR DESCRIPTION
Changes:

Removed unused `internal_networks` and `work_networks` variables from molecule `group_vars`.

Fixes #11 