### PR TITLE
inputs now need to be seperated with `-` instead of `_`

### DIFF
--- a/.github/workflows/add_issue_to_project.yml
+++ b/.github/workflows/add_issue_to_project.yml
@@ -11,5 +11,5 @@ jobs:
     steps:
       - uses: UCL-MIRSG/.github/actions/add-to-project@v0.11.0
         with:
-          app_id: ${{ secrets.APP_ID }}
-          app_pem: ${{ secrets.APP_PEM }}
+          app-id: ${{ secrets.APP_ID }}
+          app-pem: ${{ secrets.APP_PEM }}


### PR DESCRIPTION
Following changes in [UCL-MIRSG/.github#40](https://github.com/UCL-MIRSG/.github/pull/40) inputs now need to be seperated with `-` instead of `_`